### PR TITLE
Encrypt PII fields and switch email lookups to blind indices

### DIFF
--- a/migrations/0011_encrypt_pii_and_add_email_blind_index.sql
+++ b/migrations/0011_encrypt_pii_and_add_email_blind_index.sql
@@ -1,0 +1,13 @@
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS users_email_key;
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS email_blind_index TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_email_blind_index_key
+    ON users (email_blind_index)
+    WHERE email_blind_index IS NOT NULL;
+
+ALTER TABLE users
+    ALTER COLUMN date_of_birth TYPE TEXT
+    USING date_of_birth::text;

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,8 @@ pub struct Config {
     pub dragonfly_url: String,
     pub paseto_local_key: String,
     pub xchacha20_key: String,
+    pub master_encryption_key: String,
+    pub blind_index_key: String,
     pub cors_allowed_origins: Vec<String>,
     pub request_body_limit_bytes: usize,
     pub rate_limit_requests_per_minute: u32,
@@ -50,6 +52,8 @@ impl Config {
             .unwrap_or_else(|_| "haven-change-me-32-byte-secret-key!".to_string());
         let xchacha20_key = env::var("XCHACHA20_KEY")
             .unwrap_or_else(|_| "haven-change-me-xchacha20-key".to_string());
+        let master_encryption_key = env::var("MASTER_ENCRYPTION_KEY")?;
+        let blind_index_key = env::var("BLIND_INDEX_KEY")?;
         let cors_allowed_origins = env::var("CORS_ALLOWED_ORIGINS")
             .unwrap_or_else(|_| "http://localhost:5173".to_string())
             .split(',')
@@ -119,6 +123,8 @@ impl Config {
             dragonfly_url,
             paseto_local_key,
             xchacha20_key,
+            master_encryption_key,
+            blind_index_key,
             cors_allowed_origins,
             request_body_limit_bytes,
             rate_limit_requests_per_minute,
@@ -148,6 +154,14 @@ impl Config {
 
         if self.xchacha20_key.contains("change-me") || self.xchacha20_key.len() < 32 {
             return Err("XCHACHA20_KEY must be set to a strong secret (>=32 chars)".into());
+        }
+
+        if self.master_encryption_key.len() < 32 {
+            return Err("MASTER_ENCRYPTION_KEY must be set to a strong secret (>=32 chars)".into());
+        }
+
+        if self.blind_index_key.len() < 32 {
+            return Err("BLIND_INDEX_KEY must be set to a strong secret (>=32 chars)".into());
         }
 
         Ok(())

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -4,8 +4,11 @@ use chacha20poly1305::{
     aead::{Aead, Payload},
     KeyInit, XChaCha20Poly1305, XNonce,
 };
+use hmac::{Hmac, Mac};
 use rand::RngCore;
 use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
 
 #[derive(Clone)]
 pub struct CryptoManager {
@@ -93,9 +96,16 @@ impl CryptoManager {
     }
 }
 
+pub fn blind_index_string(secret: &str, value: &str) -> Result<String, AppError> {
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(secret.as_bytes())
+        .map_err(|_| AppError::Crypto("invalid blind index key".to_string()))?;
+    mac.update(value.as_bytes());
+    Ok(hex::encode(mac.finalize().into_bytes()))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::CryptoManager;
+    use super::{blind_index_string, CryptoManager};
 
     #[test]
     fn encrypt_decrypt_roundtrip_with_aad() {
@@ -137,5 +147,16 @@ mod tests {
             .expect_err("invalid token format must fail");
 
         assert!(err.to_string().contains("invalid token format"));
+    }
+
+    #[test]
+    fn blind_index_is_deterministic() {
+        let left =
+            blind_index_string("blind-index-key", "user@example.com").expect("index should work");
+        let right =
+            blind_index_string("blind-index-key", "user@example.com").expect("index should work");
+
+        assert_eq!(left, right);
+        assert_ne!(left, "user@example.com");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,10 +153,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.refresh_token_ttl_days,
     ));
     let crypto_manager = Arc::new(CryptoManager::new(&config.xchacha20_key));
+    let data_encryption_manager = Arc::new(CryptoManager::new(&config.master_encryption_key));
     let probe = crypto_manager.encrypt_string("haven-crypto-probe", Some(b"startup"))?;
     let probe_plain = crypto_manager.decrypt_to_string(&probe, Some(b"startup"))?;
     if probe_plain != "haven-crypto-probe" {
         return Err("xchacha20 startup self-test failed".into());
+    }
+    let data_probe =
+        data_encryption_manager.encrypt_string("haven-data-probe", Some(b"startup"))?;
+    let data_probe_plain =
+        data_encryption_manager.decrypt_to_string(&data_probe, Some(b"startup"))?;
+    if data_probe_plain != "haven-data-probe" {
+        return Err("master encryption startup self-test failed".into());
     }
 
     let email_client = Arc::new(EmailClient::new(&config)?);
@@ -176,6 +184,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         dragonfly_url: config.dragonfly_url.clone(),
         token_manager,
         crypto_manager,
+        data_encryption_manager,
+        blind_index_key: Arc::new(config.blind_index_key.clone()),
         email_client,
         rate_limiter,
         email_verify_ip_limiter,

--- a/src/repository/auth_repository.rs
+++ b/src/repository/auth_repository.rs
@@ -1,8 +1,8 @@
 use crate::{
-    domain::auth::{AuthUserResponse, SessionRow, UserAuthRow},
+    domain::auth::{SessionRow, UserAuthRow},
     error::AppError,
 };
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Postgres, Transaction};
 
 pub struct NewRegistrationUser {
@@ -10,22 +10,37 @@ pub struct NewRegistrationUser {
     pub username: String,
     pub display_name: String,
     pub email: String,
+    pub email_blind_index: String,
     pub srp_salt: String,
     pub srp_verifier: String,
     pub password_hash: Option<String>,
-    pub date_of_birth: NaiveDate,
+    pub date_of_birth: String,
     pub locale: String,
+}
+
+#[derive(sqlx::FromRow)]
+pub struct StoredAuthUserResponseRow {
+    pub id: i64,
+    pub username: String,
+    pub display_name: String,
+    pub email: String,
+    pub avatar_url: Option<String>,
+    pub email_verified: bool,
+    pub two_factor_enabled: bool,
+    pub account_status: String,
+    pub token_version: i32,
+    pub created_at: DateTime<Utc>,
 }
 
 pub async fn insert_user_for_registration(
     pool: &PgPool,
     new_user: NewRegistrationUser,
-) -> Result<AuthUserResponse, AppError> {
-    let result = sqlx::query_as::<_, AuthUserResponse>(
+) -> Result<StoredAuthUserResponseRow, AppError> {
+    let result = sqlx::query_as::<_, StoredAuthUserResponseRow>(
         r#"
         INSERT INTO users (
-            id, username, display_name, email, srp_salt, srp_verifier, password_hash, date_of_birth, locale
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            id, username, display_name, email, email_blind_index, srp_salt, srp_verifier, password_hash, date_of_birth, locale
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
         RETURNING id,
             username,
             display_name,
@@ -42,6 +57,7 @@ pub async fn insert_user_for_registration(
     .bind(new_user.username)
     .bind(new_user.display_name)
     .bind(new_user.email)
+    .bind(new_user.email_blind_index)
     .bind(new_user.srp_salt)
     .bind(new_user.srp_verifier)
     .bind(new_user.password_hash)
@@ -59,18 +75,18 @@ pub async fn insert_user_for_registration(
     }
 }
 
-pub async fn find_user_auth_by_email(
+pub async fn find_user_auth_by_email_blind_index(
     pool: &PgPool,
-    email: &str,
+    email_blind_index: &str,
 ) -> Result<Option<UserAuthRow>, AppError> {
     let user = sqlx::query_as::<_, UserAuthRow>(
         r#"
         SELECT id, srp_salt, srp_verifier, password_hash, account_status, token_version, totp_secret, totp_backup_codes
         FROM users
-        WHERE email = $1
+        WHERE email_blind_index = $1
         "#,
     )
-    .bind(email)
+    .bind(email_blind_index)
     .fetch_optional(pool)
     .await?;
 
@@ -195,8 +211,8 @@ pub async fn commit_tx(tx: Transaction<'_, Postgres>) -> Result<(), AppError> {
 pub async fn find_current_user(
     pool: &PgPool,
     user_id: i64,
-) -> Result<Option<AuthUserResponse>, AppError> {
-    let user = sqlx::query_as::<_, AuthUserResponse>(
+) -> Result<Option<StoredAuthUserResponseRow>, AppError> {
+    let user = sqlx::query_as::<_, StoredAuthUserResponseRow>(
         r#"
         SELECT id,
             username,
@@ -239,18 +255,18 @@ pub struct UserEmailStatusRow {
     pub email_verified: bool,
 }
 
-pub async fn find_user_email_status_by_email(
+pub async fn find_user_email_status_by_blind_index(
     pool: &PgPool,
-    email: &str,
+    email_blind_index: &str,
 ) -> Result<Option<UserEmailStatusRow>, AppError> {
     let row = sqlx::query_as::<_, UserEmailStatusRow>(
         r#"
         SELECT id, email_verified
         FROM users
-        WHERE email = $1
+        WHERE email_blind_index = $1
         "#,
     )
-    .bind(email)
+    .bind(email_blind_index)
     .fetch_optional(pool)
     .await?;
 

--- a/src/repository/user_repository.rs
+++ b/src/repository/user_repository.rs
@@ -1,21 +1,60 @@
-use crate::{
-    domain::user::{CreateUserRequest, User},
-    error::AppError,
-};
+use crate::error::AppError;
+use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 
-pub async fn create_user(pool: &PgPool, payload: CreateUserRequest) -> Result<User, AppError> {
-    let user = sqlx::query_as::<_, User>(
+pub struct StoredCreateUser {
+    pub id: i64,
+    pub username: String,
+    pub display_name: String,
+    pub email: String,
+    pub email_blind_index: String,
+    pub password_hash: String,
+    pub date_of_birth: String,
+    pub locale: String,
+    pub avatar_url: Option<String>,
+    pub banner_url: Option<String>,
+    pub accent_color: Option<String>,
+    pub bio: Option<String>,
+    pub pronouns: Option<String>,
+}
+
+#[derive(sqlx::FromRow)]
+pub struct StoredUserRow {
+    pub id: i64,
+    pub username: String,
+    pub display_name: String,
+    pub email: String,
+    pub email_verified: bool,
+    pub token_version: i32,
+    pub account_status: String,
+    pub flags: i32,
+    pub last_login_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub date_of_birth: String,
+    pub avatar_url: Option<String>,
+    pub banner_url: Option<String>,
+    pub accent_color: Option<String>,
+    pub bio: Option<String>,
+    pub pronouns: Option<String>,
+    pub locale: String,
+}
+
+pub async fn create_user(
+    pool: &PgPool,
+    payload: StoredCreateUser,
+) -> Result<StoredUserRow, AppError> {
+    let user = sqlx::query_as::<_, StoredUserRow>(
         r#"
         INSERT INTO users (
-            id, username, display_name, email, password_hash,
+            id, username, display_name, email, email_blind_index, password_hash,
             date_of_birth, locale, avatar_url, banner_url,
             accent_color, bio, pronouns
         )
         VALUES (
-            $1, $2, $3, $4, $5,
-            $6, $7, $8, $9,
-            $10, $11, $12
+            $1, $2, $3, $4, $5, $6,
+            $7, $8, $9, $10,
+            $11, $12, $13
         )
         RETURNING
             id, username, display_name, email, email_verified,
@@ -28,6 +67,7 @@ pub async fn create_user(pool: &PgPool, payload: CreateUserRequest) -> Result<Us
     .bind(payload.username)
     .bind(payload.display_name)
     .bind(payload.email)
+    .bind(payload.email_blind_index)
     .bind(payload.password_hash)
     .bind(payload.date_of_birth)
     .bind(payload.locale)
@@ -42,8 +82,8 @@ pub async fn create_user(pool: &PgPool, payload: CreateUserRequest) -> Result<Us
     Ok(user)
 }
 
-pub async fn get_user(pool: &PgPool, id: i64) -> Result<Option<User>, AppError> {
-    let user = sqlx::query_as::<_, User>(
+pub async fn get_user(pool: &PgPool, id: i64) -> Result<Option<StoredUserRow>, AppError> {
+    let user = sqlx::query_as::<_, StoredUserRow>(
         r#"
         SELECT
             id, username, display_name, email, email_verified,

--- a/src/service/auth_service.rs
+++ b/src/service/auth_service.rs
@@ -1,5 +1,6 @@
 use crate::{
     auth::{generate_id, hash_password, sha256_hex, verify_password, AuthTokens},
+    crypto::{blind_index_string, CryptoManager},
     domain::auth::{
         AuthUser, AuthUserResponse, EmailVerificationConfirmRequest, EmailVerificationRequest,
         LoginChallengeRequest, LoginChallengeResponse, LoginRequest, LoginVerifyRequest,
@@ -64,29 +65,44 @@ impl AuthService {
         }
 
         let user_id = generate_id();
+        let normalized_email = payload.email.trim().to_lowercase();
+        let encrypted_email = encrypt_user_email(
+            &self.state.data_encryption_manager,
+            user_id,
+            &normalized_email,
+        )?;
+        let email_blind_index =
+            compute_email_blind_index(&self.state.blind_index_key, &normalized_email)?;
+        let encrypted_date_of_birth = encrypt_date_of_birth(
+            &self.state.data_encryption_manager,
+            user_id,
+            &payload.date_of_birth,
+        )?;
 
         let password_hash = payload.password.as_deref().map(hash_password).transpose()?;
 
-        let user = auth_repository::insert_user_for_registration(
+        let stored_user = auth_repository::insert_user_for_registration(
             &self.state.pg_pool,
             auth_repository::NewRegistrationUser {
                 user_id,
                 username: payload.username.trim().to_lowercase(),
                 display_name: payload.display_name.trim().to_string(),
-                email: payload.email.trim().to_lowercase(),
+                email: encrypted_email,
+                email_blind_index,
                 srp_salt: payload.srp_salt,
                 srp_verifier: payload.srp_verifier,
                 password_hash,
-                date_of_birth: payload.date_of_birth,
+                date_of_birth: encrypted_date_of_birth,
                 locale: payload.locale.trim().to_lowercase(),
             },
         )
         .await?;
+        let user = build_auth_user_response(&self.state.data_encryption_manager, stored_user)?;
 
         tracing::info!(
             event = "auth.register",
             user_id = user.id,
-            email = user.email,
+            email = normalized_email,
             "user registered"
         );
         Ok(user)
@@ -103,21 +119,25 @@ impl AuthService {
 
         let normalized_email = payload.email.trim().to_lowercase();
 
-        let user =
-            match auth_repository::find_user_auth_by_email(&self.state.pg_pool, &normalized_email)
-                .await?
-            {
-                Some(user) => user,
-                None => {
-                    tracing::warn!(
-                        event = "auth.login.challenge.failed",
-                        email = normalized_email,
-                        reason = "user_not_found",
-                        "invalid credentials"
-                    );
-                    return Err(AppError::Unauthorized);
-                }
-            };
+        let email_blind_index =
+            compute_email_blind_index(&self.state.blind_index_key, &normalized_email)?;
+        let user = match auth_repository::find_user_auth_by_email_blind_index(
+            &self.state.pg_pool,
+            &email_blind_index,
+        )
+        .await?
+        {
+            Some(user) => user,
+            None => {
+                tracing::warn!(
+                    event = "auth.login.challenge.failed",
+                    email = normalized_email,
+                    reason = "user_not_found",
+                    "invalid credentials"
+                );
+                return Err(AppError::Unauthorized);
+            }
+        };
 
         if user.account_status != "active" {
             tracing::warn!(
@@ -195,21 +215,25 @@ impl AuthService {
 
         let normalized_email = payload.email.trim().to_lowercase();
 
-        let user =
-            match auth_repository::find_user_auth_by_email(&self.state.pg_pool, &normalized_email)
-                .await?
-            {
-                Some(user) => user,
-                None => {
-                    tracing::warn!(
-                        event = "auth.login.verify.failed",
-                        email = normalized_email,
-                        reason = "user_not_found",
-                        "invalid credentials"
-                    );
-                    return Err(AppError::Unauthorized);
-                }
-            };
+        let email_blind_index =
+            compute_email_blind_index(&self.state.blind_index_key, &normalized_email)?;
+        let user = match auth_repository::find_user_auth_by_email_blind_index(
+            &self.state.pg_pool,
+            &email_blind_index,
+        )
+        .await?
+        {
+            Some(user) => user,
+            None => {
+                tracing::warn!(
+                    event = "auth.login.verify.failed",
+                    email = normalized_email,
+                    reason = "user_not_found",
+                    "invalid credentials"
+                );
+                return Err(AppError::Unauthorized);
+            }
+        };
 
         if user.account_status != "active" {
             return Err(AppError::Forbidden);
@@ -339,21 +363,25 @@ impl AuthService {
 
         let normalized_email = payload.email.trim().to_lowercase();
 
-        let user =
-            match auth_repository::find_user_auth_by_email(&self.state.pg_pool, &normalized_email)
-                .await?
-            {
-                Some(user) => user,
-                None => {
-                    tracing::warn!(
-                        event = "auth.login.failed",
-                        email = normalized_email,
-                        reason = "user_not_found",
-                        "invalid credentials"
-                    );
-                    return Err(AppError::Unauthorized);
-                }
-            };
+        let email_blind_index =
+            compute_email_blind_index(&self.state.blind_index_key, &normalized_email)?;
+        let user = match auth_repository::find_user_auth_by_email_blind_index(
+            &self.state.pg_pool,
+            &email_blind_index,
+        )
+        .await?
+        {
+            Some(user) => user,
+            None => {
+                tracing::warn!(
+                    event = "auth.login.failed",
+                    email = normalized_email,
+                    reason = "user_not_found",
+                    "invalid credentials"
+                );
+                return Err(AppError::Unauthorized);
+            }
+        };
 
         if user.account_status != "active" {
             tracing::warn!(
@@ -528,6 +556,7 @@ impl AuthService {
         auth_repository::find_current_user(&self.state.pg_pool, user.id)
             .await?
             .ok_or(AppError::Unauthorized)
+            .and_then(|row| build_auth_user_response(&self.state.data_encryption_manager, row))
     }
 
     pub async fn request_email_verification(
@@ -540,6 +569,8 @@ impl AuthService {
             .map_err(|e| AppError::Validation(e.to_string()))?;
 
         let normalized_email = payload.email.trim().to_lowercase();
+        let email_blind_index =
+            compute_email_blind_index(&self.state.blind_index_key, &normalized_email)?;
 
         let ip = crate::security::extract_client_ip(headers);
         let ip_key = format!("email-verify:ip:{ip}");
@@ -557,9 +588,9 @@ impl AuthService {
             return Err(AppError::TooManyRequests);
         }
 
-        let user = match auth_repository::find_user_email_status_by_email(
+        let user = match auth_repository::find_user_email_status_by_blind_index(
             &self.state.pg_pool,
-            &normalized_email,
+            &email_blind_index,
         )
         .await?
         {
@@ -625,9 +656,11 @@ impl AuthService {
             .map_err(|e| AppError::Validation(e.to_string()))?;
 
         let normalized_email = payload.email.trim().to_lowercase();
-        let user = auth_repository::find_user_email_status_by_email(
+        let email_blind_index =
+            compute_email_blind_index(&self.state.blind_index_key, &normalized_email)?;
+        let user = auth_repository::find_user_email_status_by_blind_index(
             &self.state.pg_pool,
-            &normalized_email,
+            &email_blind_index,
         )
         .await?
         .ok_or(AppError::Unauthorized)?;
@@ -902,6 +935,79 @@ fn hash_backup_codes(codes: &[String]) -> Vec<String> {
     codes.iter().map(|c| sha256_hex(c)).collect()
 }
 
+fn compute_email_blind_index(blind_index_key: &str, email: &str) -> Result<String, AppError> {
+    blind_index_string(blind_index_key, email)
+}
+
+fn user_field_aad(user_id: i64, field: &str) -> Vec<u8> {
+    format!("user:{user_id}:{field}").into_bytes()
+}
+
+fn encrypt_user_field(
+    crypto: &CryptoManager,
+    user_id: i64,
+    field: &str,
+    value: &str,
+) -> Result<String, AppError> {
+    let aad = user_field_aad(user_id, field);
+    crypto.encrypt_string(value, Some(&aad))
+}
+
+fn decrypt_user_field(
+    crypto: &CryptoManager,
+    user_id: i64,
+    field: &str,
+    value: &str,
+) -> Result<String, AppError> {
+    if value.starts_with("v1.") {
+        let aad = user_field_aad(user_id, field);
+        return crypto.decrypt_to_string(value, Some(&aad));
+    }
+    Ok(value.to_string())
+}
+
+fn encrypt_user_email(
+    crypto: &CryptoManager,
+    user_id: i64,
+    email: &str,
+) -> Result<String, AppError> {
+    encrypt_user_field(crypto, user_id, "email", email)
+}
+
+fn decrypt_user_email(
+    crypto: &CryptoManager,
+    user_id: i64,
+    email: &str,
+) -> Result<String, AppError> {
+    decrypt_user_field(crypto, user_id, "email", email)
+}
+
+fn encrypt_date_of_birth(
+    crypto: &CryptoManager,
+    user_id: i64,
+    date_of_birth: &chrono::NaiveDate,
+) -> Result<String, AppError> {
+    encrypt_user_field(crypto, user_id, "date_of_birth", &date_of_birth.to_string())
+}
+
+fn build_auth_user_response(
+    crypto: &CryptoManager,
+    row: auth_repository::StoredAuthUserResponseRow,
+) -> Result<AuthUserResponse, AppError> {
+    Ok(AuthUserResponse {
+        id: row.id,
+        username: row.username,
+        display_name: row.display_name,
+        email: decrypt_user_email(crypto, row.id, &row.email)?,
+        avatar_url: row.avatar_url,
+        email_verified: row.email_verified,
+        two_factor_enabled: row.two_factor_enabled,
+        account_status: row.account_status,
+        token_version: row.token_version,
+        created_at: row.created_at,
+    })
+}
+
 fn consume_backup_code(stored_hashes: &[String], provided: &str) -> Option<Vec<String>> {
     let incoming_hash = sha256_hex(provided.trim());
     if !stored_hashes.iter().any(|hash| hash == &incoming_hash) {
@@ -947,4 +1053,47 @@ fn totp_code_for_timestamp(secret: &[u8], timestamp: i64) -> String {
     let modulo = 10_u32.pow(TOTP_DIGITS);
     let value = binary % modulo;
     format!("{:0width$}", value, width = TOTP_DIGITS as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        compute_email_blind_index, decrypt_user_email, encrypt_date_of_birth, encrypt_user_email,
+    };
+    use crate::crypto::CryptoManager;
+    use chrono::NaiveDate;
+
+    #[test]
+    fn email_blind_index_is_stable() {
+        let left =
+            compute_email_blind_index("blind-index-key-12345678901234567890", "user@example.com")
+                .expect("blind index should work");
+        let right =
+            compute_email_blind_index("blind-index-key-12345678901234567890", "user@example.com")
+                .expect("blind index should work");
+
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn encrypted_email_roundtrips() {
+        let crypto = CryptoManager::new("unit-test-master-encryption-key-123456");
+        let encrypted =
+            encrypt_user_email(&crypto, 42, "user@example.com").expect("email encrypts");
+        let decrypted = decrypt_user_email(&crypto, 42, &encrypted).expect("email decrypts");
+
+        assert_eq!(decrypted, "user@example.com");
+        assert_ne!(encrypted, "user@example.com");
+    }
+
+    #[test]
+    fn encrypted_date_of_birth_roundtrips() {
+        let crypto = CryptoManager::new("unit-test-master-encryption-key-123456");
+        let date = NaiveDate::from_ymd_opt(2000, 1, 1).expect("valid date");
+        let encrypted = encrypt_date_of_birth(&crypto, 9, &date).expect("dob encrypts");
+        let decrypted = super::decrypt_user_field(&crypto, 9, "date_of_birth", &encrypted)
+            .expect("dob decrypts");
+
+        assert_eq!(decrypted, date.to_string());
+    }
 }

--- a/src/service/user_service.rs
+++ b/src/service/user_service.rs
@@ -1,4 +1,5 @@
 use crate::{
+    crypto::CryptoManager,
     domain::user::{CreateUserRequest, User},
     error::AppError,
     repository::{cache_repository, user_repository},
@@ -28,7 +29,45 @@ impl UserService {
             return Err(AppError::BadRequest("email is required".to_string()));
         }
 
-        let user = user_repository::create_user(&self.state.pg_pool, payload).await?;
+        let normalized_email = payload.email.trim().to_lowercase();
+        let encrypted_email = encrypt_user_email(
+            &self.state.data_encryption_manager,
+            payload.id,
+            &normalized_email,
+        )?;
+        let email_blind_index =
+            compute_email_blind_index(&self.state.blind_index_key, &normalized_email)?;
+        let encrypted_date_of_birth = encrypt_date_of_birth(
+            &self.state.data_encryption_manager,
+            payload.id,
+            &payload.date_of_birth,
+        )?;
+        let encrypted_bio = encrypt_optional_bio(
+            &self.state.data_encryption_manager,
+            payload.id,
+            payload.bio.as_deref(),
+        )?;
+
+        let stored = user_repository::create_user(
+            &self.state.pg_pool,
+            user_repository::StoredCreateUser {
+                id: payload.id,
+                username: payload.username,
+                display_name: payload.display_name,
+                email: encrypted_email,
+                email_blind_index,
+                password_hash: payload.password_hash,
+                date_of_birth: encrypted_date_of_birth,
+                locale: payload.locale,
+                avatar_url: payload.avatar_url,
+                banner_url: payload.banner_url,
+                accent_color: payload.accent_color,
+                bio: encrypted_bio,
+                pronouns: payload.pronouns,
+            },
+        )
+        .await?;
+        let user = build_user_response(&self.state.data_encryption_manager, stored)?;
         let cache_key = format!("cache:user:profile:{}", user.id);
         cache_repository::set_json(
             &self.state.redis_pool,
@@ -50,7 +89,8 @@ impl UserService {
 
         let user = user_repository::get_user(&self.state.pg_pool, id)
             .await?
-            .ok_or(AppError::NotFound)?;
+            .ok_or(AppError::NotFound)
+            .and_then(|row| build_user_response(&self.state.data_encryption_manager, row))?;
 
         cache_repository::set_json(
             &self.state.redis_pool,
@@ -69,4 +109,113 @@ impl UserService {
         cache_repository::del_key(&self.state.redis_pool, &cache_key).await?;
         Ok(())
     }
+}
+
+fn compute_email_blind_index(blind_index_key: &str, email: &str) -> Result<String, AppError> {
+    crate::crypto::blind_index_string(blind_index_key, email)
+}
+
+fn user_field_aad(user_id: i64, field: &str) -> Vec<u8> {
+    format!("user:{user_id}:{field}").into_bytes()
+}
+
+fn encrypt_user_field(
+    crypto: &CryptoManager,
+    user_id: i64,
+    field: &str,
+    value: &str,
+) -> Result<String, AppError> {
+    let aad = user_field_aad(user_id, field);
+    crypto.encrypt_string(value, Some(&aad))
+}
+
+fn decrypt_user_field(
+    crypto: &CryptoManager,
+    user_id: i64,
+    field: &str,
+    value: &str,
+) -> Result<String, AppError> {
+    if value.starts_with("v1.") {
+        let aad = user_field_aad(user_id, field);
+        return crypto.decrypt_to_string(value, Some(&aad));
+    }
+    Ok(value.to_string())
+}
+
+fn encrypt_user_email(
+    crypto: &CryptoManager,
+    user_id: i64,
+    email: &str,
+) -> Result<String, AppError> {
+    encrypt_user_field(crypto, user_id, "email", email)
+}
+
+fn decrypt_user_email(
+    crypto: &CryptoManager,
+    user_id: i64,
+    email: &str,
+) -> Result<String, AppError> {
+    decrypt_user_field(crypto, user_id, "email", email)
+}
+
+fn encrypt_date_of_birth(
+    crypto: &CryptoManager,
+    user_id: i64,
+    date_of_birth: &chrono::NaiveDate,
+) -> Result<String, AppError> {
+    encrypt_user_field(crypto, user_id, "date_of_birth", &date_of_birth.to_string())
+}
+
+fn decrypt_date_of_birth(
+    crypto: &CryptoManager,
+    user_id: i64,
+    date_of_birth: &str,
+) -> Result<chrono::NaiveDate, AppError> {
+    let value = decrypt_user_field(crypto, user_id, "date_of_birth", date_of_birth)?;
+    chrono::NaiveDate::parse_from_str(&value, "%Y-%m-%d")
+        .map_err(|err| AppError::Crypto(format!("invalid date_of_birth payload: {err}")))
+}
+
+fn encrypt_optional_bio(
+    crypto: &CryptoManager,
+    user_id: i64,
+    bio: Option<&str>,
+) -> Result<Option<String>, AppError> {
+    bio.map(|value| encrypt_user_field(crypto, user_id, "bio", value))
+        .transpose()
+}
+
+fn decrypt_optional_bio(
+    crypto: &CryptoManager,
+    user_id: i64,
+    bio: Option<&str>,
+) -> Result<Option<String>, AppError> {
+    bio.map(|value| decrypt_user_field(crypto, user_id, "bio", value))
+        .transpose()
+}
+
+fn build_user_response(
+    crypto: &CryptoManager,
+    row: user_repository::StoredUserRow,
+) -> Result<User, AppError> {
+    Ok(User {
+        id: row.id,
+        username: row.username,
+        display_name: row.display_name,
+        email: decrypt_user_email(crypto, row.id, &row.email)?,
+        email_verified: row.email_verified,
+        token_version: row.token_version,
+        account_status: row.account_status,
+        flags: row.flags,
+        last_login_at: row.last_login_at,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        date_of_birth: decrypt_date_of_birth(crypto, row.id, &row.date_of_birth)?,
+        avatar_url: row.avatar_url,
+        banner_url: row.banner_url,
+        accent_color: row.accent_color,
+        bio: decrypt_optional_bio(crypto, row.id, row.bio.as_deref())?,
+        pronouns: row.pronouns,
+        locale: row.locale,
+    })
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,6 +14,8 @@ pub struct AppState {
     pub dragonfly_url: String,
     pub token_manager: Arc<TokenManager>,
     pub crypto_manager: Arc<CryptoManager>,
+    pub data_encryption_manager: Arc<CryptoManager>,
+    pub blind_index_key: Arc<String>,
     pub email_client: Arc<EmailClient>,
     pub rate_limiter: Arc<SimpleRateLimiter>,
     pub email_verify_ip_limiter: Arc<SimpleRateLimiter>,


### PR DESCRIPTION
## Summary
- require MASTER_ENCRYPTION_KEY and BLIND_INDEX_KEY at startup
- encrypt email, date_of_birth, and bio at rest while decrypting them before API responses
- add deterministic HMAC-SHA256 blind indices for email-based auth and verification lookups
- add the users.email_blind_index schema change and move uniqueness to the blind-index column

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

Closes #6