### PR TITLE
Implement auth, websocket, realtime, and privacy issue improvements

### DIFF
--- a/.agent/CONTINUITY.md
+++ b/.agent/CONTINUITY.md
@@ -1,0 +1,8 @@
+# CONTINUITY
+
+2026-04-20T10:45:00+02:00 [TOOL] `UNCONFIRMED` missing file at `.agent/CONTINUITY.md`; created baseline memory file for repo continuity.
+2026-04-20T10:45:00+02:00 [USER] Create OpenAPI document for Haven backend for tools like Scalar.
+2026-04-20T10:45:00+02:00 [CODE] Added `docs/openapi.yaml` for current HTTP API under `/api/v1`; excludes WebSocket upgrade routes.
+2026-04-21T10:21:55+02:00 [USER] Implement open feature issues one-by-one, add tests when needed, do not run server locally, and open one PR after `cargo test` and `cargo clippy` pass.
+2026-04-21T10:21:55+02:00 [CODE] Implemented issue set #10-#14 in code: centralized auth 2FA checks, added identity-based login limiting, moved WS auth to first-message token auth with per-connection throttling and server-side identity enforcement, enforced E2EE payload size caps, switched realtime publish path to Redis Pub/Sub only, and added deleted-account anonymization sweep.
+2026-04-21T10:21:55+02:00 [TOOL] Verified green with `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings`.

--- a/src/domain/e2ee.rs
+++ b/src/domain/e2ee.rs
@@ -1,6 +1,9 @@
+use crate::error::AppError;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
+
+pub const MAX_E2EE_PAYLOAD_BYTES: usize = 65_536;
 
 #[derive(Debug, Deserialize, Validate)]
 pub struct OneTimePrekeyInput {
@@ -62,4 +65,42 @@ pub struct NewMessageRecipientKey {
     pub recipient_user_id: i64,
     pub encrypted_message_key: String,
     pub one_time_prekey_id: Option<i64>,
+}
+
+pub fn validate_e2ee_payload_size(
+    ciphertext: Option<&str>,
+    nonce: Option<&str>,
+    aad: Option<&str>,
+) -> Result<(), AppError> {
+    let total_len =
+        ciphertext.map_or(0, str::len) + nonce.map_or(0, str::len) + aad.map_or(0, str::len);
+
+    if total_len > MAX_E2EE_PAYLOAD_BYTES {
+        return Err(AppError::PayloadTooLarge(format!(
+            "combined ciphertext, nonce, and aad exceed {MAX_E2EE_PAYLOAD_BYTES} bytes"
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_e2ee_payload_size, MAX_E2EE_PAYLOAD_BYTES};
+
+    #[test]
+    fn accepts_payload_at_limit() {
+        let ciphertext = "a".repeat(MAX_E2EE_PAYLOAD_BYTES - 6);
+        validate_e2ee_payload_size(Some(&ciphertext), Some("123"), Some("456"))
+            .expect("payload at limit should pass");
+    }
+
+    #[test]
+    fn rejects_payload_above_limit() {
+        let ciphertext = "a".repeat(MAX_E2EE_PAYLOAD_BYTES);
+        let err = validate_e2ee_payload_size(Some(&ciphertext), Some("123"), Some("456"))
+            .expect_err("payload above limit must fail");
+
+        assert!(err.to_string().contains("payload too large"));
+    }
 }

--- a/src/domain/realtime.rs
+++ b/src/domain/realtime.rs
@@ -1,5 +1,15 @@
+use crate::error::AppError;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+
+pub const MAX_WS_MESSAGES_PER_SECOND: u32 = 5;
+pub const WS_MESSAGE_RATE_LIMIT_WINDOW_SECONDS: u64 = 1;
+
+pub struct E2eePayloadFields<'a> {
+    pub ciphertext: Option<&'a str>,
+    pub nonce: Option<&'a str>,
+    pub aad: Option<&'a str>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RealtimeEvent {
@@ -11,19 +21,19 @@ pub struct RealtimeEvent {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ClientRealtimeMessage {
+    Authenticate {
+        token: String,
+    },
     Join {
         channel: String,
-        user_id: Option<i64>,
     },
     Broadcast {
         channel: String,
-        user_id: Option<i64>,
         payload: serde_json::Value,
     },
     Presence {
-        user_id: i64,
         status: String,
     },
     Ping,
@@ -43,5 +53,89 @@ impl RealtimeEvent {
             payload,
             ts: Utc::now().timestamp_millis(),
         }
+    }
+}
+
+pub fn websocket_message_rate_limit_key(session_id: &str) -> String {
+    format!("ws:msg:{session_id}")
+}
+
+pub fn extract_e2ee_payload_fields(
+    payload: &serde_json::Value,
+) -> Result<E2eePayloadFields<'_>, AppError> {
+    let Some(payload_obj) = payload.as_object() else {
+        return Ok(E2eePayloadFields {
+            ciphertext: None,
+            nonce: None,
+            aad: None,
+        });
+    };
+
+    Ok(E2eePayloadFields {
+        ciphertext: json_string_field(payload_obj, "ciphertext")?,
+        nonce: json_string_field(payload_obj, "nonce")?,
+        aad: json_string_field(payload_obj, "aad")?,
+    })
+}
+
+fn json_string_field<'a>(
+    payload: &'a serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<Option<&'a str>, AppError> {
+    match payload.get(field) {
+        Some(serde_json::Value::String(value)) => Ok(Some(value.as_str())),
+        Some(serde_json::Value::Null) | None => Ok(None),
+        Some(_) => Err(AppError::BadRequest(format!("{field} must be a string"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        extract_e2ee_payload_fields, websocket_message_rate_limit_key, ClientRealtimeMessage,
+    };
+
+    #[test]
+    fn authenticate_message_deserializes() {
+        let message: ClientRealtimeMessage =
+            serde_json::from_str(r#"{"type":"authenticate","token":"token-123"}"#)
+                .expect("authenticate message should parse");
+
+        assert!(matches!(
+            message,
+            ClientRealtimeMessage::Authenticate { token } if token == "token-123"
+        ));
+    }
+
+    #[test]
+    fn join_rejects_client_supplied_user_id() {
+        let err = serde_json::from_str::<ClientRealtimeMessage>(
+            r#"{"type":"join","channel":"1","user_id":42}"#,
+        )
+        .expect_err("join should reject user_id");
+
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn extracts_optional_e2ee_fields_from_payload() {
+        let payload = serde_json::json!({
+            "ciphertext": "abc",
+            "nonce": "def",
+            "aad": "ghi"
+        });
+
+        let fields = extract_e2ee_payload_fields(&payload).expect("fields should parse");
+        assert_eq!(fields.ciphertext, Some("abc"));
+        assert_eq!(fields.nonce, Some("def"));
+        assert_eq!(fields.aad, Some("ghi"));
+    }
+
+    #[test]
+    fn websocket_message_rate_limit_key_is_namespaced() {
+        assert_eq!(
+            websocket_message_rate_limit_key("session-1"),
+            "ws:msg:session-1"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,8 @@ pub enum AppError {
     Conflict(String),
     #[error("validation error: {0}")]
     Validation(String),
+    #[error("payload too large: {0}")]
+    PayloadTooLarge(String),
     #[error("crypto error: {0}")]
     Crypto(String),
     #[error("too many requests")]
@@ -51,6 +53,7 @@ impl IntoResponse for AppError {
             AppError::Forbidden => StatusCode::FORBIDDEN,
             AppError::Conflict(_) => StatusCode::CONFLICT,
             AppError::Validation(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            AppError::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
             AppError::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
             AppError::Service(_) => StatusCode::INTERNAL_SERVER_ERROR,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
@@ -96,5 +99,11 @@ mod tests {
     async fn maps_internal_errors_to_500() {
         let response = AppError::Crypto("broken".to_string()).into_response();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn maps_payload_too_large_to_413() {
+        let response = AppError::PayloadTooLarge("too big".to_string()).into_response();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.rate_limit_requests_per_minute,
         Duration::from_secs(60),
     ));
+    let login_identity_limiter = Arc::new(SimpleRateLimiter::new(5, Duration::from_secs(60)));
     let email_verify_ip_limiter = Arc::new(SimpleRateLimiter::new(5, Duration::from_secs(900)));
     let email_verify_email_limiter = Arc::new(SimpleRateLimiter::new(5, Duration::from_secs(900)));
     let (realtime_tx, _) = broadcast::channel(512);
@@ -188,6 +189,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         blind_index_key: Arc::new(config.blind_index_key.clone()),
         email_client,
         rate_limiter,
+        login_identity_limiter,
         email_verify_ip_limiter,
         email_verify_email_limiter,
         realtime_tx,
@@ -197,6 +199,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     RealtimeService::new(state.clone()).spawn_fanout_bridge();
     maintenance::spawn_avatar_cleanup(state.clone());
+    maintenance::spawn_deleted_account_cleanup(state.clone());
 
     let cors_layer = if config.cors_allowed_origins.is_empty() {
         CorsLayer::new()

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -1,9 +1,14 @@
-use crate::{error::AppError, state::AppState};
-use chrono::{Local, LocalResult, TimeZone, Timelike};
+use crate::{
+    crypto::blind_index_string, error::AppError, repository::user_repository, state::AppState,
+};
+use chrono::{Duration as ChronoDuration, Local, LocalResult, TimeZone, Timelike, Utc};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use tokio::time::{sleep, Duration};
 use tracing::{info, warn};
+
+const DELETED_ACCOUNT_RETENTION_DAYS: i64 = 30;
+const DELETED_ACCOUNT_SWEEP_INTERVAL_HOURS: u32 = 24;
 
 pub fn spawn_avatar_cleanup(state: AppState) {
     tokio::spawn(async move {
@@ -16,6 +21,23 @@ pub fn spawn_avatar_cleanup(state: AppState) {
                     event = "avatar.cleanup.failed",
                     error = %err,
                     "avatar cleanup failed"
+                );
+            }
+        }
+    });
+}
+
+pub fn spawn_deleted_account_cleanup(state: AppState) {
+    tokio::spawn(async move {
+        loop {
+            let sleep_for = time_until_next_run(DELETED_ACCOUNT_SWEEP_INTERVAL_HOURS);
+            sleep(sleep_for).await;
+
+            if let Err(err) = cleanup_deleted_accounts(&state).await {
+                warn!(
+                    event = "account.cleanup.failed",
+                    error = %err,
+                    "deleted account cleanup failed"
                 );
             }
         }
@@ -126,7 +148,134 @@ async fn cleanup_orphan_avatars(state: &AppState) -> Result<(), AppError> {
     Ok(())
 }
 
+async fn cleanup_deleted_accounts(state: &AppState) -> Result<(), AppError> {
+    let cutoff = Utc::now() - ChronoDuration::days(DELETED_ACCOUNT_RETENTION_DAYS);
+    let users = user_repository::list_deleted_users_pending_cleanup(&state.pg_pool, cutoff).await?;
+
+    if users.is_empty() {
+        return Ok(());
+    }
+
+    let mut anonymized = 0usize;
+    for user in users {
+        let profile = deleted_user_profile(user.id, &state.blind_index_key)?;
+        let encrypted_email = encrypt_deleted_user_email(
+            &state.data_encryption_manager,
+            user.id,
+            &profile.placeholder_email,
+        )?;
+        let encrypted_dob =
+            encrypt_deleted_user_date_of_birth(&state.data_encryption_manager, user.id)?;
+
+        user_repository::anonymize_deleted_user(
+            &state.pg_pool,
+            user.id,
+            &profile.username,
+            &profile.display_name,
+            &encrypted_email,
+            &profile.email_blind_index,
+            &encrypted_dob,
+        )
+        .await?;
+        anonymized += 1;
+    }
+
+    info!(
+        event = "account.cleanup.complete",
+        anonymized, "deleted account cleanup completed"
+    );
+
+    Ok(())
+}
+
 fn parse_user_id_from_path(path: &Path) -> Option<i64> {
     let name = path.file_name()?.to_string_lossy();
     name.parse::<i64>().ok()
+}
+
+struct DeletedUserProfile {
+    username: String,
+    display_name: String,
+    placeholder_email: String,
+    email_blind_index: String,
+}
+
+fn deleted_user_profile(
+    user_id: i64,
+    blind_index_key: &str,
+) -> Result<DeletedUserProfile, AppError> {
+    let placeholder_email = format!("deleted-user-{user_id}@deleted.haven.local");
+    let email_blind_index = blind_index_string(blind_index_key, &placeholder_email)?;
+
+    Ok(DeletedUserProfile {
+        username: format!("deleted-user-{user_id}"),
+        display_name: "Deleted User".to_string(),
+        placeholder_email,
+        email_blind_index,
+    })
+}
+
+fn encrypt_deleted_user_email(
+    crypto: &crate::crypto::CryptoManager,
+    user_id: i64,
+    email: &str,
+) -> Result<String, AppError> {
+    let aad = format!("user:{user_id}:email");
+    crypto.encrypt_string(email, Some(aad.as_bytes()))
+}
+
+fn encrypt_deleted_user_date_of_birth(
+    crypto: &crate::crypto::CryptoManager,
+    user_id: i64,
+) -> Result<String, AppError> {
+    let aad = format!("user:{user_id}:date_of_birth");
+    crypto.encrypt_string("1970-01-01", Some(aad.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        deleted_user_profile, encrypt_deleted_user_date_of_birth, encrypt_deleted_user_email,
+        time_until_next_run,
+    };
+    use crate::crypto::CryptoManager;
+
+    #[test]
+    fn deleted_user_profile_uses_deleted_user_identity() {
+        let profile = deleted_user_profile(42, "blind-index-key-12345678901234567890")
+            .expect("profile should build");
+
+        assert_eq!(profile.username, "deleted-user-42");
+        assert_eq!(profile.display_name, "Deleted User");
+        assert_eq!(
+            profile.placeholder_email,
+            "deleted-user-42@deleted.haven.local"
+        );
+        assert_ne!(profile.email_blind_index, profile.placeholder_email);
+    }
+
+    #[test]
+    fn deleted_user_pii_encryption_roundtrips() {
+        let crypto = CryptoManager::new("unit-test-master-encryption-key-123456");
+        let encrypted_email =
+            encrypt_deleted_user_email(&crypto, 7, "deleted-user-7@deleted.haven.local")
+                .expect("email encryption should work");
+        let encrypted_dob =
+            encrypt_deleted_user_date_of_birth(&crypto, 7).expect("dob encryption should work");
+
+        let email = crypto
+            .decrypt_to_string(&encrypted_email, Some(b"user:7:email"))
+            .expect("email decryption should work");
+        let dob = crypto
+            .decrypt_to_string(&encrypted_dob, Some(b"user:7:date_of_birth"))
+            .expect("dob decryption should work");
+
+        assert_eq!(email, "deleted-user-7@deleted.haven.local");
+        assert_eq!(dob, "1970-01-01");
+    }
+
+    #[test]
+    fn next_run_duration_is_non_zero() {
+        assert!(time_until_next_run(24).as_secs() <= 24 * 60 * 60);
+    }
 }

--- a/src/repository/user_repository.rs
+++ b/src/repository/user_repository.rs
@@ -40,6 +40,11 @@ pub struct StoredUserRow {
     pub locale: String,
 }
 
+#[derive(sqlx::FromRow)]
+pub struct DeletedUserCleanupRow {
+    pub id: i64,
+}
+
 pub async fn create_user(
     pool: &PgPool,
     payload: StoredCreateUser,
@@ -108,6 +113,76 @@ pub async fn update_avatar_url(
 ) -> Result<(), AppError> {
     sqlx::query("UPDATE users SET avatar_url = $1 WHERE id = $2")
         .bind(avatar_url)
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+pub async fn list_deleted_users_pending_cleanup(
+    pool: &PgPool,
+    older_than: DateTime<Utc>,
+) -> Result<Vec<DeletedUserCleanupRow>, AppError> {
+    let rows = sqlx::query_as::<_, DeletedUserCleanupRow>(
+        r#"
+        SELECT id
+        FROM users
+        WHERE account_status = 'deleted'
+          AND updated_at < $1
+        "#,
+    )
+    .bind(older_than)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows)
+}
+
+pub async fn anonymize_deleted_user(
+    pool: &PgPool,
+    user_id: i64,
+    username: &str,
+    display_name: &str,
+    encrypted_email: &str,
+    email_blind_index: &str,
+    encrypted_date_of_birth: &str,
+) -> Result<(), AppError> {
+    sqlx::query(
+        r#"
+        UPDATE users
+        SET username = $2,
+            display_name = $3,
+            email = $4,
+            email_blind_index = $5,
+            email_verified = FALSE,
+            password_hash = NULL,
+            srp_salt = NULL,
+            srp_verifier = NULL,
+            token_version = token_version + 1,
+            totp_secret = NULL,
+            totp_backup_codes = NULL,
+            date_of_birth = $6,
+            avatar_url = NULL,
+            banner_url = NULL,
+            accent_color = NULL,
+            bio = NULL,
+            pronouns = NULL,
+            locale = 'und'
+        WHERE id = $1
+          AND account_status = 'deleted'
+        "#,
+    )
+    .bind(user_id)
+    .bind(username)
+    .bind(display_name)
+    .bind(encrypted_email)
+    .bind(email_blind_index)
+    .bind(encrypted_date_of_birth)
+    .execute(pool)
+    .await?;
+
+    sqlx::query("DELETE FROM auth_sessions WHERE user_id = $1")
         .bind(user_id)
         .execute(pool)
         .await?;

--- a/src/service/auth_service.rs
+++ b/src/service/auth_service.rs
@@ -41,6 +41,16 @@ struct CachedAuthStatus {
     token_version: i32,
 }
 
+struct TwoFactorVerification<'a> {
+    event_name: &'static str,
+    user_id: i64,
+    email: &'a str,
+    encrypted_secret: Option<&'a str>,
+    encrypted_backup_codes: Option<&'a str>,
+    totp_code: Option<&'a str>,
+    backup_code: Option<&'a str>,
+}
+
 #[derive(Clone)]
 pub struct AuthService {
     state: AppState,
@@ -121,6 +131,8 @@ impl AuthService {
 
         let email_blind_index =
             compute_email_blind_index(&self.state.blind_index_key, &normalized_email)?;
+        self.enforce_login_identity_rate_limit(&email_blind_index)
+            .await?;
         let user = match auth_repository::find_user_auth_by_email_blind_index(
             &self.state.pg_pool,
             &email_blind_index,
@@ -280,57 +292,16 @@ impl AuthService {
             })?;
 
         // Handle 2FA if enabled
-        if let Some(secret) = user
-            .totp_secret
-            .as_deref()
-            .map(|value| decrypt_totp_secret(&self.state.data_encryption_manager, user.id, value))
-            .transpose()?
-        {
-            match (payload.totp_code.as_deref(), payload.backup_code.as_deref()) {
-                (Some(code), _) => {
-                    if !verify_totp_code(&secret, code)? {
-                        tracing::warn!(
-                            event = "auth.login.verify.failed",
-                            email = payload.email,
-                            reason = "invalid_totp",
-                            "invalid 2fa code"
-                        );
-                        return Err(AppError::Unauthorized);
-                    }
-                }
-                (None, Some(backup_code)) => {
-                    let current_codes = decrypt_backup_code_hashes(
-                        &self.state.data_encryption_manager,
-                        user.id,
-                        user.totp_backup_codes.as_deref(),
-                    )?;
-                    let updated_codes = consume_backup_code(&current_codes, backup_code)
-                        .ok_or_else(|| {
-                            tracing::warn!(
-                                event = "auth.login.verify.failed",
-                                email = payload.email,
-                                reason = "invalid_backup_code",
-                                "invalid backup code"
-                            );
-                            AppError::Unauthorized
-                        })?;
-                    let encrypted_codes = encrypt_backup_code_hashes(
-                        &self.state.data_encryption_manager,
-                        user.id,
-                        &updated_codes,
-                    )?;
-                    auth_repository::update_backup_codes(
-                        &self.state.pg_pool,
-                        user.id,
-                        encrypted_codes,
-                    )
-                    .await?;
-                }
-                (None, None) => {
-                    return Err(AppError::TwoFactorRequired);
-                }
-            }
-        }
+        self.verify_2fa_credentials(TwoFactorVerification {
+            event_name: "auth.login.verify.failed",
+            user_id: user.id,
+            email: &payload.email,
+            encrypted_secret: user.totp_secret.as_deref(),
+            encrypted_backup_codes: user.totp_backup_codes.as_deref(),
+            totp_code: payload.totp_code.as_deref(),
+            backup_code: payload.backup_code.as_deref(),
+        })
+        .await?;
 
         let session_id = generate_id();
         let tokens =
@@ -379,6 +350,8 @@ impl AuthService {
 
         let email_blind_index =
             compute_email_blind_index(&self.state.blind_index_key, &normalized_email)?;
+        self.enforce_login_identity_rate_limit(&email_blind_index)
+            .await?;
         let user = match auth_repository::find_user_auth_by_email_blind_index(
             &self.state.pg_pool,
             &email_blind_index,
@@ -427,57 +400,16 @@ impl AuthService {
             return Err(AppError::Unauthorized);
         }
 
-        if let Some(secret) = user
-            .totp_secret
-            .as_deref()
-            .map(|value| decrypt_totp_secret(&self.state.data_encryption_manager, user.id, value))
-            .transpose()?
-        {
-            match (payload.totp_code.as_deref(), payload.backup_code.as_deref()) {
-                (Some(code), _) => {
-                    if !verify_totp_code(&secret, code)? {
-                        tracing::warn!(
-                            event = "auth.login.failed",
-                            email = payload.email,
-                            reason = "invalid_totp",
-                            "invalid 2fa code"
-                        );
-                        return Err(AppError::Unauthorized);
-                    }
-                }
-                (None, Some(backup_code)) => {
-                    let current_codes = decrypt_backup_code_hashes(
-                        &self.state.data_encryption_manager,
-                        user.id,
-                        user.totp_backup_codes.as_deref(),
-                    )?;
-                    let updated_codes = consume_backup_code(&current_codes, backup_code)
-                        .ok_or_else(|| {
-                            tracing::warn!(
-                                event = "auth.login.failed",
-                                email = payload.email,
-                                reason = "invalid_backup_code",
-                                "invalid backup code"
-                            );
-                            AppError::Unauthorized
-                        })?;
-                    let encrypted_codes = encrypt_backup_code_hashes(
-                        &self.state.data_encryption_manager,
-                        user.id,
-                        &updated_codes,
-                    )?;
-                    auth_repository::update_backup_codes(
-                        &self.state.pg_pool,
-                        user.id,
-                        encrypted_codes,
-                    )
-                    .await?;
-                }
-                (None, None) => {
-                    return Err(AppError::TwoFactorRequired);
-                }
-            }
-        }
+        self.verify_2fa_credentials(TwoFactorVerification {
+            event_name: "auth.login.failed",
+            user_id: user.id,
+            email: &payload.email,
+            encrypted_secret: user.totp_secret.as_deref(),
+            encrypted_backup_codes: user.totp_backup_codes.as_deref(),
+            totp_code: payload.totp_code.as_deref(),
+            backup_code: payload.backup_code.as_deref(),
+        })
+        .await?;
 
         let session_id = generate_id();
         let tokens =
@@ -921,6 +853,82 @@ impl AuthService {
 
         Ok(AuthUser { id: user_id })
     }
+
+    async fn enforce_login_identity_rate_limit(
+        &self,
+        email_blind_index: &str,
+    ) -> Result<(), AppError> {
+        let key = login_identity_rate_limit_key(email_blind_index);
+        if !self.state.login_identity_limiter.allow(&key).await {
+            return Err(AppError::TooManyRequests);
+        }
+
+        Ok(())
+    }
+
+    async fn verify_2fa_credentials(
+        &self,
+        verification: TwoFactorVerification<'_>,
+    ) -> Result<(), AppError> {
+        let Some(secret) = verification
+            .encrypted_secret
+            .map(|value| {
+                decrypt_totp_secret(
+                    &self.state.data_encryption_manager,
+                    verification.user_id,
+                    value,
+                )
+            })
+            .transpose()?
+        else {
+            return Ok(());
+        };
+
+        match (verification.totp_code, verification.backup_code) {
+            (Some(code), _) => {
+                if !verify_totp_code(&secret, code)? {
+                    tracing::warn!(
+                        event = verification.event_name,
+                        email = verification.email,
+                        reason = "invalid_totp",
+                        "invalid 2fa code"
+                    );
+                    return Err(AppError::Unauthorized);
+                }
+            }
+            (None, Some(backup_code)) => {
+                let current_codes = decrypt_backup_code_hashes(
+                    &self.state.data_encryption_manager,
+                    verification.user_id,
+                    verification.encrypted_backup_codes,
+                )?;
+                let updated_codes =
+                    consume_backup_code(&current_codes, backup_code).ok_or_else(|| {
+                        tracing::warn!(
+                            event = verification.event_name,
+                            email = verification.email,
+                            reason = "invalid_backup_code",
+                            "invalid backup code"
+                        );
+                        AppError::Unauthorized
+                    })?;
+                let encrypted_codes = encrypt_backup_code_hashes(
+                    &self.state.data_encryption_manager,
+                    verification.user_id,
+                    &updated_codes,
+                )?;
+                auth_repository::update_backup_codes(
+                    &self.state.pg_pool,
+                    verification.user_id,
+                    encrypted_codes,
+                )
+                .await?;
+            }
+            (None, None) => return Err(AppError::TwoFactorRequired),
+        }
+
+        Ok(())
+    }
 }
 
 fn extract_bearer(headers: &HeaderMap) -> Result<String, AppError> {
@@ -1119,6 +1127,10 @@ fn consume_backup_code(stored_hashes: &[String], provided: &str) -> Option<Vec<S
     Some(updated)
 }
 
+fn login_identity_rate_limit_key(email_blind_index: &str) -> String {
+    format!("login:identity:{email_blind_index}")
+}
+
 fn verify_totp_code(secret_base32: &str, code: &str) -> Result<bool, AppError> {
     let secret = base32::decode(base32::Alphabet::Rfc4648 { padding: false }, secret_base32)
         .ok_or_else(|| AppError::BadRequest("invalid 2fa secret".to_string()))?;
@@ -1156,10 +1168,11 @@ fn totp_code_for_timestamp(secret: &[u8], timestamp: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_email_blind_index, decrypt_backup_code_hashes, decrypt_totp_secret,
-        decrypt_user_email, encrypt_backup_code_hashes, encrypt_date_of_birth, encrypt_totp_secret,
-        encrypt_user_email,
+        compute_email_blind_index, consume_backup_code, decrypt_backup_code_hashes,
+        decrypt_totp_secret, decrypt_user_email, encrypt_backup_code_hashes, encrypt_date_of_birth,
+        encrypt_totp_secret, encrypt_user_email, login_identity_rate_limit_key,
     };
+    use crate::auth::sha256_hex;
     use crate::crypto::CryptoManager;
     use chrono::NaiveDate;
 
@@ -1220,5 +1233,22 @@ mod tests {
             .expect("dob decrypts");
 
         assert_eq!(decrypted, date.to_string());
+    }
+
+    #[test]
+    fn consume_backup_code_removes_matching_hash() {
+        let keep = sha256_hex("keep-me");
+        let used = sha256_hex("use-me");
+
+        let updated = consume_backup_code(&[keep.clone(), used], "use-me")
+            .expect("matching backup code should be consumed");
+
+        assert_eq!(updated, vec![keep]);
+    }
+
+    #[test]
+    fn login_identity_rate_limit_key_is_namespaced() {
+        let key = login_identity_rate_limit_key("blind-index");
+        assert_eq!(key, "login:identity:blind-index");
     }
 }

--- a/src/service/chat_service.rs
+++ b/src/service/chat_service.rs
@@ -6,6 +6,7 @@ use crate::{
             CreateMessageRequest, CreateServerRequest, DmMessage, DmThreadSummary, Message,
             PaginationQuery, Server,
         },
+        e2ee::validate_e2ee_payload_size,
         realtime::RealtimeEvent,
     },
     error::AppError,
@@ -233,6 +234,12 @@ impl ChatService {
                     .ok_or(AppError::Validation(
                         "nonce is required for e2ee message".to_string(),
                     ))?;
+
+                validate_e2ee_payload_size(
+                    Some(ciphertext.as_str()),
+                    Some(nonce.as_str()),
+                    payload.aad.as_deref(),
+                )?;
 
                 let recipient_key_boxes =
                     payload
@@ -615,6 +622,12 @@ impl ChatService {
                 .ok_or(AppError::Validation(
                     "nonce is required for e2ee message".to_string(),
                 ))?;
+
+            validate_e2ee_payload_size(
+                Some(ciphertext.as_str()),
+                Some(nonce.as_str()),
+                payload.aad.as_deref(),
+            )?;
 
             (
                 "[e2ee]".to_string(),

--- a/src/service/realtime_service.rs
+++ b/src/service/realtime_service.rs
@@ -18,16 +18,7 @@ impl RealtimeService {
         self.state.realtime_tx.subscribe()
     }
 
-    pub fn publish(&self, event: RealtimeEvent) -> Result<(), AppError> {
-        self.state
-            .realtime_tx
-            .send(event)
-            .map(|_| ())
-            .map_err(|_| AppError::BadRequest("failed to publish realtime event".to_string()))
-    }
-
     pub async fn publish_with_fanout(&self, event: RealtimeEvent) -> Result<(), AppError> {
-        self.publish(event.clone())?;
         realtime_repository::publish_event(&self.state.redis_pool, &event).await
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,6 +18,7 @@ pub struct AppState {
     pub blind_index_key: Arc<String>,
     pub email_client: Arc<EmailClient>,
     pub rate_limiter: Arc<SimpleRateLimiter>,
+    pub login_identity_limiter: Arc<SimpleRateLimiter>,
     pub email_verify_ip_limiter: Arc<SimpleRateLimiter>,
     pub email_verify_email_limiter: Arc<SimpleRateLimiter>,
     pub realtime_tx: broadcast::Sender<RealtimeEvent>,

--- a/src/transport/ws/mod.rs
+++ b/src/transport/ws/mod.rs
@@ -1,29 +1,30 @@
 use crate::{
     auth::generate_id,
-    domain::realtime::{ClientRealtimeMessage, RealtimeEvent},
+    domain::{
+        e2ee::validate_e2ee_payload_size,
+        realtime::{
+            extract_e2ee_payload_fields, websocket_message_rate_limit_key, ClientRealtimeMessage,
+            RealtimeEvent, MAX_WS_MESSAGES_PER_SECOND, WS_MESSAGE_RATE_LIMIT_WINDOW_SECONDS,
+        },
+    },
     error::AppError,
     repository::chat_repository,
+    security::SimpleRateLimiter,
     service::ServiceFactory,
     state::AppState,
 };
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
-        Query, State,
+        State,
     },
     response::IntoResponse,
     routing::get,
     Router,
 };
 use futures_util::{sink::SinkExt, stream::StreamExt};
-use serde::Deserialize;
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::RwLock;
-
-#[derive(Debug, Default, Deserialize)]
-struct WsAuthQuery {
-    access_token: Option<String>,
-}
 
 #[derive(Debug, Default)]
 struct WsConnectionState {
@@ -39,30 +40,9 @@ pub fn router() -> Router<AppState> {
 
 async fn ws_upgrade(
     State(state): State<AppState>,
-    Query(query): Query<WsAuthQuery>,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, AppError> {
-    let actor_user_id = match query.access_token.as_deref() {
-        Some(token) => Some(
-            ServiceFactory::new(state.clone())
-                .auth()
-                .authenticate_access_token(token)
-                .await?
-                .id,
-        ),
-        None => None,
-    };
-
-    Ok(ws.on_upgrade(move |socket| handle_socket(state, socket, actor_user_id)))
-}
-
-fn bind_actor_user_id(bound: &mut Option<i64>, candidate: Option<i64>) -> Result<Option<i64>, ()> {
-    match (*bound, candidate) {
-        (Some(existing), Some(next)) if next > 0 && next != existing => Err(()),
-        (Some(existing), _) => Ok(Some(existing)),
-        (None, Some(_)) => Err(()),
-        (None, _) => Ok(None),
-    }
+    Ok(ws.on_upgrade(move |socket| handle_socket(state, socket)))
 }
 
 fn is_friend_request_event_relevant_for_actor(event: &RealtimeEvent, actor_user_id: i64) -> bool {
@@ -125,14 +105,14 @@ async fn user_can_join_channel(state: &AppState, user_id: i64, channel: &str) ->
         .unwrap_or(false)
 }
 
-async fn handle_socket(state: AppState, socket: WebSocket, actor_user_id: Option<i64>) {
+async fn handle_socket(state: AppState, socket: WebSocket) {
     let service_factory = ServiceFactory::new(state.clone());
     let service = service_factory.realtime();
     let mut rx = service.subscribe();
     let (mut sender, mut receiver) = socket.split();
     let ws_session_id = format!("{}", generate_id());
     let connection_state = Arc::new(RwLock::new(WsConnectionState {
-        actor_user_id,
+        actor_user_id: None,
         subscribed_channels: HashSet::new(),
     }));
     let send_connection_state = Arc::clone(&connection_state);
@@ -165,14 +145,25 @@ async fn handle_socket(state: AppState, socket: WebSocket, actor_user_id: Option
 
     let recv_state = state.clone();
     let recv_state_for_membership = state.clone();
+    let recv_state_for_auth = state.clone();
     let recv_connection_state = Arc::clone(&connection_state);
     let recv_ws_session_id = ws_session_id.clone();
     let mut recv_task = tokio::spawn(async move {
         let recv_service = ServiceFactory::new(recv_state).realtime();
+        let auth_service = ServiceFactory::new(recv_state_for_auth).auth();
+        let message_limiter = SimpleRateLimiter::new(
+            MAX_WS_MESSAGES_PER_SECOND,
+            std::time::Duration::from_secs(WS_MESSAGE_RATE_LIMIT_WINDOW_SECONDS),
+        );
+        let message_limit_key = websocket_message_rate_limit_key(&recv_ws_session_id);
 
         while let Some(Ok(message)) = receiver.next().await {
             match message {
                 Message::Text(text) => {
+                    if !message_limiter.allow(&message_limit_key).await {
+                        continue;
+                    }
+
                     let mut bytes = text.as_bytes().to_vec();
                     let parsed: Result<ClientRealtimeMessage, _> =
                         simd_json::serde::from_slice(&mut bytes);
@@ -180,77 +171,92 @@ async fn handle_socket(state: AppState, socket: WebSocket, actor_user_id: Option
                         continue;
                     };
                     match client_msg {
-                        ClientRealtimeMessage::Join { channel, user_id } => {
-                            let resolved_user_id = {
-                                let mut state = recv_connection_state.write().await;
-                                match bind_actor_user_id(&mut state.actor_user_id, user_id) {
-                                    Ok(Some(actor_user_id)) => {
-                                        state.subscribed_channels.insert(channel.clone());
-                                        Some(actor_user_id)
-                                    }
-                                    _ => None,
-                                }
+                        ClientRealtimeMessage::Authenticate { token } => {
+                            let Ok(actor_user_id) = auth_service
+                                .authenticate_access_token(&token)
+                                .await
+                                .map(|user| user.id)
+                            else {
+                                continue;
                             };
 
-                            if resolved_user_id.is_none() {
+                            let mut state = recv_connection_state.write().await;
+                            match state.actor_user_id {
+                                Some(existing) if existing != actor_user_id => continue,
+                                Some(_) => {}
+                                None => {
+                                    state.actor_user_id = Some(actor_user_id);
+                                }
+                            }
+                        }
+                        ClientRealtimeMessage::Join { channel } => {
+                            let actor_user_id = {
+                                let mut state = recv_connection_state.write().await;
+                                let Some(actor_user_id) = state.actor_user_id else {
+                                    continue;
+                                };
+                                if !state.subscribed_channels.contains(&channel) {
+                                    state.subscribed_channels.insert(channel.clone());
+                                }
+                                actor_user_id
+                            };
+
+                            if !user_can_join_channel(
+                                &recv_state_for_membership,
+                                actor_user_id,
+                                &channel,
+                            )
+                            .await
+                            {
+                                let mut state = recv_connection_state.write().await;
+                                state.subscribed_channels.remove(&channel);
                                 continue;
                             }
 
-                            if let Some(actor_user_id) = resolved_user_id {
-                                if !user_can_join_channel(
-                                    &recv_state_for_membership,
-                                    actor_user_id,
-                                    &channel,
-                                )
-                                .await
-                                {
-                                    let mut state = recv_connection_state.write().await;
-                                    state.subscribed_channels.remove(&channel);
-                                    continue;
-                                }
-
-                                let _ = recv_service
-                                    .cache_ws_session(&recv_ws_session_id, actor_user_id)
-                                    .await;
-                                let _ = recv_service.set_presence(actor_user_id, "online").await;
-                            }
+                            let _ = recv_service
+                                .cache_ws_session(&recv_ws_session_id, actor_user_id)
+                                .await;
+                            let _ = recv_service.set_presence(actor_user_id, "online").await;
                         }
-                        ClientRealtimeMessage::Broadcast {
-                            channel,
-                            user_id,
-                            payload,
-                        } => {
-                            let (rejected, resolved_user_id) = {
-                                let mut state = recv_connection_state.write().await;
-                                if !state.subscribed_channels.contains(&channel) {
-                                    (true, None)
-                                } else {
-                                    match bind_actor_user_id(&mut state.actor_user_id, user_id) {
-                                        Ok(Some(resolved)) => (false, Some(resolved)),
-                                        Ok(None) => (true, None),
-                                        Err(()) => (true, None),
+                        ClientRealtimeMessage::Broadcast { channel, payload } => {
+                            let actor_user_id = {
+                                let state = recv_connection_state.read().await;
+                                match state.actor_user_id {
+                                    Some(actor_user_id)
+                                        if state.subscribed_channels.contains(&channel) =>
+                                    {
+                                        actor_user_id
                                     }
+                                    _ => continue,
                                 }
                             };
-                            if rejected {
+
+                            let fields = match extract_e2ee_payload_fields(&payload) {
+                                Ok(fields) => fields,
+                                Err(_) => continue,
+                            };
+                            if validate_e2ee_payload_size(
+                                fields.ciphertext,
+                                fields.nonce,
+                                fields.aad,
+                            )
+                            .is_err()
+                            {
                                 continue;
                             }
 
                             let event = RealtimeEvent::new(
                                 "broadcast",
-                                resolved_user_id,
+                                Some(actor_user_id),
                                 Some(channel),
                                 payload,
                             );
                             let _ = recv_service.publish_with_fanout(event).await;
                         }
-                        ClientRealtimeMessage::Presence { user_id, status } => {
-                            let Some(actor_user_id) = ({
-                                let mut state = recv_connection_state.write().await;
-                                bind_actor_user_id(&mut state.actor_user_id, Some(user_id))
-                                    .ok()
-                                    .flatten()
-                            }) else {
+                        ClientRealtimeMessage::Presence { status } => {
+                            let Some(actor_user_id) =
+                                ({ recv_connection_state.read().await.actor_user_id })
+                            else {
                                 continue;
                             };
 


### PR DESCRIPTION
## Summary
- centralize 2FA verification and add identity-based login rate limiting for auth flows
- move websocket auth to an explicit first-message authenticate flow, enforce server-side identity, add per-connection message throttling, and validate E2EE payload size on websocket broadcasts
- route realtime fanout through Redis Pub/Sub only and add automated anonymization cleanup for soft-deleted accounts

## Issues
- addresses #10
- addresses #11
- addresses #12
- addresses #13
- addresses #14

## Verification
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Notes
- did not run the local server, per request
- left unrelated existing worktree changes in `README.md` and `docs/` untouched